### PR TITLE
Give cache directory path in HITRAN docs

### DIFF
--- a/docs/hitran/hitran.rst
+++ b/docs/hitran/hitran.rst
@@ -9,9 +9,9 @@ Getting started
 
 This module provides an interface to the `HITRAN`_ database API.  It can
 download a data file including transitions for a particular molecule in a given
-wavenumber range.  The file is downloaded in the `~astroquery.hitran.cache_location`
-directory and can be opened with a reader function that returns a table of
-spectral lines including all accessible parameters.
+wavenumber range.  The file is downloaded in the default cache directory 
+``~/.astropy/cache/astroquery/hitran`` and can be opened with a reader function
+that returns a table of spectral lines including all accessible parameters.
 
 Examples
 ========


### PR DESCRIPTION
This also removes a sphinx warning and should fix the CI issue.