### PR TITLE
ignore warnings at import time in astrometry.net

### DIFF
--- a/astroquery/astrometry_net/core.py
+++ b/astroquery/astrometry_net/core.py
@@ -104,10 +104,10 @@ class AstrometryNetClass(BaseQuery):
                             default=key_info['default'],
                             values=key_info['allowed']))
 
-    def __init__(self):
+    def __init__(self, ignore_warning=False):
         """ Show a warning message if the API key is not in the configuration file. """
         super(AstrometryNetClass, self).__init__()
-        if not conf.api_key:
+        if not ignore_warning and not conf.api_key:
             log.warning("Astrometry.net API key not found in configuration file")
             log.warning("You need to manually edit the configuration file and add it")
             log.warning(
@@ -417,4 +417,5 @@ class AstrometryNetClass(BaseQuery):
 
 
 # the default tool for users to interact with is an instance of the Class
-AstrometryNet = AstrometryNetClass()
+# we default to ignoring the warning so this warning isn't raised at import time
+AstrometryNet = AstrometryNetClass(ignore_warning=True)


### PR DESCRIPTION
addresses issue #1544 by explicitly ignoring warnings when the instance of the astrometry.net class is created at import time.